### PR TITLE
Trim extracted text

### DIFF
--- a/src/main/kotlin/com/eny/i18n/plugin/ide/actions/ExtractI18nIntentionAction.kt
+++ b/src/main/kotlin/com/eny/i18n/plugin/ide/actions/ExtractI18nIntentionAction.kt
@@ -50,7 +50,7 @@ class ExtractI18nIntentionAction : PsiElementBaseIntentionAction(), IntentionAct
     private fun doInvoke(editor: Editor, project: Project, element: PsiElement) {
         val document = editor.document
         val extractor = getExtractor(element)
-        val text = extractor.text(element)
+        val text = extractor.text(element).trim()
         val requestResult = request.key(project, text)
         if (requestResult.isCancelled) return
         if (requestResult.key == null) {


### PR DESCRIPTION
When extracting text from a template, it is sometimes on a new line like so

```html
<div>
    Hello
</div>
```

Extracting the text leads a lot of whitespaces being included. This PR adds a call to `trim()` to remove the whitespace.