### PR TITLE
Vue: Don't inject json in i18n tags that aren't top-level

### DIFF
--- a/src/main/kotlin/com/eny/i18n/plugin/ide/injections/VueSFCTranslationInjector.kt
+++ b/src/main/kotlin/com/eny/i18n/plugin/ide/injections/VueSFCTranslationInjector.kt
@@ -13,7 +13,7 @@ import com.intellij.psi.PsiLanguageInjectionHost
 class VueSFCTranslationInjector : LanguageInjector {
 
     override fun getLanguagesToInject(host: PsiLanguageInjectionHost, places: InjectedLanguagePlaces) {
-        if (host.isValidHost && XmlPatterns.xmlText().withParent(XmlPatterns.xmlTag().withName("i18n")).accepts(host)) {
+        if (host.isValidHost && XmlPatterns.xmlText().withParent(XmlPatterns.xmlTag().withName("i18n").withParent(XmlPatterns.psiFile())).accepts(host)) {
             places.addPlace(JsonLanguage.INSTANCE, TextRange(0, host.textRange.length), null, null)
         }
     }


### PR DESCRIPTION
[Component Interpolation](https://kazupon.github.io/vue-i18n/guide/interpolation.html#basic-usage) uses the same `<i18n>` tag that the Single File Component uses. This fix prevents injecting JSON in the component interpolation case like this

```html
<template>
    <div>
        <i18n>...</i18n>
    </div>
</template>
```