### PR TITLE
Add special handling for attributes in vue templates

### DIFF
--- a/src/main/kotlin/com/eny/i18n/plugin/factory/TranslationExtractor.kt
+++ b/src/main/kotlin/com/eny/i18n/plugin/factory/TranslationExtractor.kt
@@ -1,6 +1,7 @@
 package com.eny.i18n.plugin.factory
 
 import com.eny.i18n.plugin.key.FullKey
+import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.util.TextRange
 import com.intellij.patterns.ElementPattern
 import com.intellij.psi.PsiElement
@@ -34,6 +35,9 @@ interface TranslationExtractor {
      * Get template to substitute translation with
      */
     fun template(element: PsiElement): (argument: String) -> String = {"i18n.t($it)"}
+
+    fun postProcess(editor: Editor, offset: Int) {
+    }
 }
 
 /**

--- a/src/main/kotlin/com/eny/i18n/plugin/ide/actions/ExtractI18nIntentionAction.kt
+++ b/src/main/kotlin/com/eny/i18n/plugin/ide/actions/ExtractI18nIntentionAction.kt
@@ -13,7 +13,7 @@ import com.intellij.openapi.project.Project
 import com.intellij.openapi.ui.Messages
 import com.intellij.psi.PsiElement
 
-internal class DefaultExtractor: TranslationExtractor {
+internal class DefaultExtractor : TranslationExtractor {
     override fun canExtract(element: PsiElement): Boolean = false
     override fun text(element: PsiElement): String = ""
     override fun isExtracted(element: PsiElement): Boolean = false
@@ -42,8 +42,8 @@ class ExtractI18nIntentionAction : PsiElementBaseIntentionAction(), IntentionAct
             .getInstance(element.project)
             .mainFactory()
             .translationExtractors()
-            .filter {it.canExtract(element)}
-            .whenMatches {extractors -> !extractors.any {it.isExtracted(element)}}
+            .filter { it.canExtract(element) }
+            .whenMatches { extractors -> !extractors.any { it.isExtracted(element) } }
             ?.firstOrNull()
             ?: DefaultExtractor()
 
@@ -64,9 +64,10 @@ class ExtractI18nIntentionAction : PsiElementBaseIntentionAction(), IntentionAct
         val template = extractor.template(element)
         val range = extractor.textRange(element)
         WriteCommandAction.runWriteCommandAction(project) {
-            keyExtractor.tryToResolveTranslationFile(project, i18nKey, text, editor, {
+            keyExtractor.tryToResolveTranslationFile(project, i18nKey, text, editor) {
                 document.replaceString(range.startOffset, range.endOffset, template("'${i18nKey.source}'"))
-            })
+                extractor.postProcess(editor, range.startOffset)
+            }
         }
         editor.caretModel.primaryCaret.removeSelection()
     }

--- a/src/main/kotlin/com/eny/i18n/plugin/language/vue/VueLanguageFactory.kt
+++ b/src/main/kotlin/com/eny/i18n/plugin/language/vue/VueLanguageFactory.kt
@@ -6,20 +6,27 @@ import com.eny.i18n.plugin.key.FullKey
 import com.eny.i18n.plugin.key.parser.KeyParser
 import com.eny.i18n.plugin.parser.LiteralKeyExtractor
 import com.eny.i18n.plugin.parser.type
-import com.eny.i18n.plugin.utils.*
+import com.eny.i18n.plugin.utils.default
+import com.eny.i18n.plugin.utils.toBoolean
+import com.eny.i18n.plugin.utils.unQuote
+import com.eny.i18n.plugin.utils.whenMatches
 import com.intellij.lang.javascript.JavascriptLanguage
 import com.intellij.lang.javascript.patterns.JSPatterns
 import com.intellij.lang.javascript.psi.JSCallExpression
 import com.intellij.lang.javascript.psi.JSLiteralExpression
+import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.util.TextRange
 import com.intellij.patterns.ElementPattern
-import com.intellij.patterns.ElementPatternCondition
 import com.intellij.patterns.PatternCondition
 import com.intellij.patterns.PlatformPatterns
+import com.intellij.psi.PsiDocumentManager
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiWhiteSpace
 import com.intellij.psi.html.HtmlTag
 import com.intellij.psi.util.PsiTreeUtil
+import com.intellij.psi.util.parentOfType
+import com.intellij.psi.xml.XmlAttribute
+import com.intellij.psi.xml.XmlAttributeValue
 import com.intellij.psi.xml.XmlText
 import com.intellij.psi.xml.XmlToken
 import com.intellij.util.ProcessingContext
@@ -56,10 +63,24 @@ internal class VueTranslationExtractor: TranslationExtractor {
 
     override fun template(element: PsiElement): (argument: String) -> String =
         when {
-            element.isVueTemplate() -> ({"this.\$t($it)"})
-            element.isVue() -> ({"{{ \$t($it) }}"})
-            else -> ({"\$t($it)"})
+            element.isVueScript() -> ({ "this.\$t($it)" })
+            element.isVueTemplateAttribute() -> ({ "\"\$t($it)\"" })
+            element.isVue() -> ({ "{{ \$t($it) }}" })
+            else -> ({ "\$t($it)" })
         }
+
+    override fun postProcess(editor: Editor, offset: Int) {
+        val file = PsiDocumentManager.getInstance(editor.project!!).getPsiFile(editor.document)!!
+        val attribute = file.findElementAt(offset)?.parentOfType<XmlAttribute>()
+
+        if (attribute != null) {
+            val nameElement = attribute.firstChild
+
+            if (!nameElement.text.startsWith(":")) {
+                editor.document.insertString(nameElement.textOffset, ":")
+            }
+        }
+    }
 
     private fun getTextElement(element: PsiElement): PsiElement =
         if (element.isBorderToken()) {
@@ -67,10 +88,12 @@ internal class VueTranslationExtractor: TranslationExtractor {
         } else {
             element.whenMatches { it.isVueText() }?.parent.default(element)
         }
+
     private fun PsiElement.isJs(): Boolean = this.language == JavascriptLanguage.INSTANCE
     private fun PsiElement.isVueJs(): Boolean = this.language == VueJSLanguage.INSTANCE
-    private fun PsiElement.isVue():Boolean = this.containingFile.fileType == VueFileType.INSTANCE
-    private fun PsiElement.isVueTemplate():Boolean = this.isVue() && PsiTreeUtil.findFirstParent(this, {it is HtmlTag && it.name == "script"}).toBoolean()
+    private fun PsiElement.isVue(): Boolean = this.containingFile.fileType == VueFileType.INSTANCE
+    private fun PsiElement.isVueTemplateAttribute(): Boolean = this.isVue() && this.parent is XmlAttributeValue
+    private fun PsiElement.isVueScript(): Boolean = this.isVue() && PsiTreeUtil.findFirstParent(this, { it is HtmlTag && it.name == "script" }).toBoolean()
     private fun PsiElement.isVueText(): Boolean = (this is PsiWhiteSpace) || (this is XmlToken)
     private fun PsiElement.isBorderToken(): Boolean = this.text == "</"
 }


### PR DESCRIPTION
- don't insert curly braces
- if the attribute name doesn't have a colon (:), add one

Example before:

```html
<Foo label="Name" />
```

After:

```html
<Foo :label="$t('name')" />
```