### PR TITLE
in vue scripts, add call to toString()

### DIFF
--- a/src/main/kotlin/com/eny/i18n/plugin/language/vue/VueLanguageFactory.kt
+++ b/src/main/kotlin/com/eny/i18n/plugin/language/vue/VueLanguageFactory.kt
@@ -63,7 +63,8 @@ internal class VueTranslationExtractor: TranslationExtractor {
 
     override fun template(element: PsiElement): (argument: String) -> String =
         when {
-            element.isVueScript() -> ({ "this.\$t($it).toString()" })
+            element.isVueScript() && element.parent.isTypeScript() -> ({ "this.\$t($it).toString()" })
+            element.isVueScript() -> ({ "this.\$t($it)" })
             element.isVueTemplateAttribute() -> ({ "\"\$t($it)\"" })
             element.isVue() -> ({ "{{ \$t($it) }}" })
             else -> ({ "\$t($it)" })
@@ -96,6 +97,7 @@ internal class VueTranslationExtractor: TranslationExtractor {
     private fun PsiElement.isVueScript(): Boolean = this.isVue() && PsiTreeUtil.findFirstParent(this, { it is HtmlTag && it.name == "script" }).toBoolean()
     private fun PsiElement.isVueText(): Boolean = (this is PsiWhiteSpace) || (this is XmlToken)
     private fun PsiElement.isBorderToken(): Boolean = this.text == "</"
+    private fun PsiElement.isTypeScript(): Boolean = this.language.isKindOf("TypeScript")
 }
 
 internal class VueFoldingProvider: FoldingProvider {

--- a/src/main/kotlin/com/eny/i18n/plugin/language/vue/VueLanguageFactory.kt
+++ b/src/main/kotlin/com/eny/i18n/plugin/language/vue/VueLanguageFactory.kt
@@ -63,7 +63,7 @@ internal class VueTranslationExtractor: TranslationExtractor {
 
     override fun template(element: PsiElement): (argument: String) -> String =
         when {
-            element.isVueScript() -> ({ "this.\$t($it)" })
+            element.isVueScript() -> ({ "this.\$t($it).toString()" })
             element.isVueTemplateAttribute() -> ({ "\"\$t($it)\"" })
             element.isVue() -> ({ "{{ \$t($it) }}" })
             else -> ({ "\$t($it)" })

--- a/src/test/kotlin/com/eny/i18n/plugin/utils/generator/code/VueTsCodeGenerator.kt
+++ b/src/test/kotlin/com/eny/i18n/plugin/utils/generator/code/VueTsCodeGenerator.kt
@@ -1,0 +1,64 @@
+package com.eny.i18n.plugin.utils.generator.code
+
+class VueTsCodeGenerator: CodeGenerator {
+
+    override fun ext(): String = "vue"
+
+    override fun generate(key: String, index: Int): String {
+        val f = 't'
+        return """
+            <template>
+                <div id="app">
+                    <h1>{{ \$$f('ref.section.key') }}</h1>
+                    <div>{{title}}</div>
+                </div>
+            </template>
+            <style>
+                h1 {color: #42b983;}
+            </style>
+            <script lang="ts">
+                export default {
+                    name: "AppHeader",
+                    computed: {
+                        title(): string {
+                            const expr: string = 'ts here';
+                            return $key;
+                        }
+                    }
+                }
+            </script>
+        """
+    }
+
+    override fun generateInvalid(key: String): String = """
+        <template>
+            <h1>{{\$\d($key)}}</h1>
+        </template>
+    """
+
+    override fun generateBlock(text: String, index: Int): String {
+        val f = 't'
+        return """
+            <template>
+                <div id="app">
+                    <h1>{{ \$$f('ref.section.key') }}</h1>
+                    <div>{{title}}</div>
+                </div>
+            </template>
+            <style>
+                h1 {color: #42b983;}
+            </style>
+            <script lang="ts">
+                export default {
+                    name: "AppHeader",
+                    computed: {
+                        title(): string {
+                            const expr: string = 'ts here';
+                            return $text;
+                        }
+                    }
+                }
+            </script>
+        """
+    }
+}


### PR DESCRIPTION
The `$t` function of vue-i18n returns `type TranslateResult = string | LocaleMessages;`. When using TypeScript, the type checker will complain when you use the return value in a place where a string is expected.

This PR adds a call to `.toString()` in the generated code to prevent type errors. This should be safe, but maybe JS users won't be happy with the extra code. In this case, we could add a setting, to control this behavior. 

Let me know, what you think.